### PR TITLE
Update HttpClient-android.cpp

### DIFF
--- a/cocos/network/HttpClient-android.cpp
+++ b/cocos/network/HttpClient-android.cpp
@@ -714,7 +714,7 @@ void HttpClient::processResponse(HttpResponse* response, char* responseMessage)
     char *messageInfo = urlConnection.getResponseMessage();
     if (messageInfo)
     {
-        strcpy(responseMessage, messageInfo);
+        strncpy(responseMessage, messageInfo, RESPONSE_BUFFER_SIZE-1);
         free(messageInfo);
     }
 


### PR DESCRIPTION
*fix the crash caused by http error message is too long at android 4.4